### PR TITLE
Fix Dockerfile -  ca-certificates-java dependency problem java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.9-bullseye
 
 RUN apt-get update -y && apt-get install -y inkscape latexmk texlive texlive-latex-extra
 


### PR DESCRIPTION
A change to the docker image python:slim made the docker image unable to complete. 

I currently changed it to python:3.9-bullseye but there might be a better image replacement and/or configuration for/of the python:slim image.

Here is the full error:
```
Setting up ca-certificates-java (20230103) ...
Exception in thread "main" java.lang.InternalError: Error loading java.security file
	at java.base/java.security.Security.initialize(Security.java:106)
	at java.base/java.security.Security$1.run(Security.java:84)
	at java.base/java.security.Security$1.run(Security.java:82)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at java.base/java.security.Security.<clinit>(Security.java:82)
	at java.base/sun.security.jca.ProviderList.<init>(ProviderList.java:178)
	at java.base/sun.security.jca.ProviderList$2.run(ProviderList.java:96)
	at java.base/sun.security.jca.ProviderList$2.run(ProviderList.java:94)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at java.base/sun.security.jca.ProviderList.fromSecurityProperties(ProviderList.java:93)
	at java.base/sun.security.jca.Providers.<clinit>(Providers.java:55)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:156)
	at java.base/java.security.cert.CertificateFactory.getInstance(CertificateFactory.java:193)
	at org.debian.security.KeyStoreHandler.<init>(KeyStoreHandler.java:50)
	at org.debian.security.UpdateCertificates.<init>(UpdateCertificates.java:65)
	at org.debian.security.UpdateCertificates.main(UpdateCertificates.java:51)
dpkg: error processing package ca-certificates-java (--configure):
 installed ca-certificates-java package post-installation script subprocess returned error exit status 1
Setting up libruby:amd64 (1:3.1) ...
Setting up default-jre-headless (2:1.17-74) ...
Setting up libwww-perl (6.68-1) ...
Setting up ruby-rubygems (3.3.15-2) ...
Setting up ruby (1:3.1) ...
Setting up rake (13.0.6-3) ...
dpkg: dependency problems prevent configuration of openjdk-17-jre-headless:amd64:
 openjdk-17-jre-headless:amd64 depends on ca-certificates-java (>= 20190405~); however:
  Package ca-certificates-java is not configured yet.

dpkg: error processing package openjdk-17-jre-headless:amd64 (--configure):
 dependency problems - leaving unconfigured
Setting up ruby-sdbm:amd64 (1.0.0-5+b1) ...
Setting up liblwp-protocol-https-perl (6.10-1) ...
Setting up libxml-parser-perl (2.46-4) ...
Setting up libruby3.1:amd64 (3.1.2-7) ...
dpkg: dependency problems prevent configuration of openjdk-17-jre:amd64:
 openjdk-17-jre:amd64 depends on openjdk-17-jre-headless (= 17.0.7+7-1~deb12u1); however:
  Package openjdk-17-jre-headless:amd64 is not configured yet.

dpkg: error processing package openjdk-17-jre:amd64 (--configure):
 dependency problems - leaving unconfigured
Setting up libxml-twig-perl (1:3.52-2) ...
Setting up libnet-dbus-perl (1.2.0-2) ...
dpkg: dependency problems prevent configuration of default-jre:
 default-jre depends on openjdk-17-jre; however:
  Package openjdk-17-jre:amd64 is not configured yet.

dpkg: error processing package default-jre (--configure):
 dependency problems - leaving unconfigured
 ```